### PR TITLE
fix: fixed run test warnings in LINQ and OOPS.

### DIFF
--- a/src/LINQ/Tasks/Task1.cs
+++ b/src/LINQ/Tasks/Task1.cs
@@ -23,7 +23,7 @@ public class Task1
 
         var filteredProducts = products.Where(product => product.Category == "Electronics" && product.Price > 500)
                                        .OrderByDescending(product => product.Price).ToList()
-                                       .Select(product => new { product.Name, product.Price })
+                                       .Select(product => new { Name = (string?)product.Name, product.Price })
                                        .ToList();
 
         Console.WriteLine("\n\nFiltered products under the category \"Electronics\" with a price greater than $500 and with only ProductName and Price ( In descending order by price ) : ");

--- a/src/LINQ/Tasks/Task5/Task5.cs
+++ b/src/LINQ/Tasks/Task5/Task5.cs
@@ -26,12 +26,12 @@ public class Task5
             .SortBy(product => product.Price)
             .Join(suppliers,  (product, supplier) => product.ID == supplier.ProductId, (supplier, product) => new
             {
-                supplier.ID,
-                supplier.Name,
-                supplier.Category,
+                ID = (string?)supplier.ID,
+                Name = (string?)supplier.Name,
+                Category = (string?)supplier.Category,
                 supplier.Price,
-                product.SupplierName,
-                product.SupplierId,
+                SupplierName = (string?)product.SupplierName,
+                SupplierId = (string?)product.SupplierId,
             })
             .Execute();
 

--- a/src/OOPS/Task1/Circle.cs
+++ b/src/OOPS/Task1/Circle.cs
@@ -19,7 +19,7 @@ public class Circle : Shape
     /// <returns>Area of the circle</returns>
     public override double CalculateArea()
     {
-        return Math.PI * Radius * Radius;
+        return Math.PI * this.Radius * this.Radius;
     }
 
     /// <summary>


### PR DESCRIPTION
## What does this pull request accomplish?

Fixed the run test warnings in old assignments

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

